### PR TITLE
Support dynacast. (#690)

### DIFF
--- a/engine.go
+++ b/engine.go
@@ -74,6 +74,8 @@ type RTCEngine struct {
 	OnRestarted         func(*livekit.JoinResponse)
 	OnResuming          func()
 	OnResumed           func()
+	OnLocalTrackSubscribed    func(trackSubscribed *livekit.TrackSubscribed)
+	OnSubscribedQualityUpdate func(subscribedQualityUpdate *livekit.SubscribedQualityUpdate)
 }
 
 func NewRTCEngine() *RTCEngine {
@@ -108,6 +110,16 @@ func NewRTCEngine() *RTCEngine {
 	e.client.OnLeave = e.handleLeave
 	e.client.OnTokenRefresh = func(refreshToken string) {
 		e.token.Store(refreshToken)
+	}
+	e.client.OnLocalTrackSubscribed = func(trackSubscribed *livekit.TrackSubscribed) {
+		if f := e.OnLocalTrackSubscribed; f != nil {
+			f(trackSubscribed)
+		}
+	}
+	e.client.OnSubscribedQualityUpdate = func(subscribedQualityUpdate *livekit.SubscribedQualityUpdate) {
+		if f := e.OnSubscribedQualityUpdate; f != nil {
+			f(subscribedQualityUpdate)
+		}
 	}
 	e.client.OnClose = func() { e.handleDisconnect(false) }
 

--- a/localtrack.go
+++ b/localtrack.go
@@ -359,7 +359,7 @@ func (s *LocalTrack) WriteSample(sample media.Sample, opts *SampleWriteOptions) 
 	//   4. PrevDroppedPackets -> number of dropped packets before this sample
 	//
 	// The goal here is to calculate RTP time stamp of provided sample.
-	// Priority of what is used (eevn if multiple are provided)
+	// Priority of what is used (even if multiple are provided)
 	//   1. PacketTimestamp
 	//   2. Timestamp
 	//   3. Duration
@@ -602,6 +602,7 @@ func (s *LocalTrack) writeWorker(provider SampleProvider, onComplete func()) {
 				}
 			}
 
+			sample.Timestamp = nextSampleTime
 			if err := s.WriteSample(sample, opts); err != nil {
 				s.log.Errorw("could not write sample", err)
 				return

--- a/publication.go
+++ b/publication.go
@@ -72,8 +72,31 @@ func (p *trackPublicationBase) Track() Track {
 }
 
 func (p *trackPublicationBase) MimeType() string {
+	// This requires some more work.
+	// TrackInfo has a top level MimeType which is not set
+	// on server side till the track is published.
+	// So, it is not available in the TrackPublishedResponse.
+	//
+	// But, if client specified SimulcastCodecs in AddTrackRequest,
+	// the TrackPublishedResponse will have Codecs populated and
+	// that will have the MimeType specified in AddTrackRequest.
+	// Just taking the first one here which has a non-nil MimeType.
+	// This is okay (for tracks published from here)
+	// as of 2025-05-12, 1:30 pm Pacific as
+	// Go SDK does not (yet) support simulcast codec feature.
+	//
+	// When simulcast codec feature is added, this struct needs
+	// to be updated to handle multiple mime types
 	if info, ok := p.info.Load().(*livekit.TrackInfo); ok {
-		return info.MimeType
+		if info.MimeType != "" {
+			return info.MimeType
+		}
+
+		for _, codec := range info.Codecs {
+			if codec.MimeType != "" {
+				return codec.MimeType
+			}
+		}
 	}
 	return ""
 }

--- a/remoteparticipant.go
+++ b/remoteparticipant.go
@@ -94,8 +94,11 @@ func (p *RemoteParticipant) updateInfo(pi *livekit.ParticipantInfo) {
 	}
 }
 
-func (p *RemoteParticipant) addSubscribedMediaTrack(track *webrtc.TrackRemote, trackSID string,
-	receiver *webrtc.RTPReceiver) {
+func (p *RemoteParticipant) addSubscribedMediaTrack(
+	track *webrtc.TrackRemote,
+	trackSID string,
+	receiver *webrtc.RTPReceiver,
+) {
 	pub := p.getPublication(trackSID)
 	if pub == nil {
 		// wait for metadata to arrive

--- a/room.go
+++ b/room.go
@@ -199,6 +199,8 @@ func NewRoom(callback *RoomCallback) *Room {
 	engine.OnResumed = r.handleResumed
 	engine.client.OnLocalTrackUnpublished = r.handleLocalTrackUnpublished
 	engine.client.OnTrackRemoteMuted = r.handleTrackRemoteMuted
+	engine.OnLocalTrackSubscribed = r.handleLocalTrackSubscribed
+	engine.OnSubscribedQualityUpdate = r.handleSubscribedQualityUpdate
 
 	return r
 }
@@ -671,6 +673,49 @@ func (r *Room) handleLocalTrackUnpublished(msg *livekit.TrackUnpublishedResponse
 	err := r.LocalParticipant.UnpublishTrack(msg.TrackSid)
 	if err != nil {
 		r.log.Errorw("could not unpublish track", err, "trackID", msg.TrackSid)
+	}
+}
+
+func (r *Room) handleLocalTrackSubscribed(trackSubscribed *livekit.TrackSubscribed) {
+	trackPublication := r.LocalParticipant.getLocalPublication(trackSubscribed.TrackSid)
+	if trackPublication == nil {
+		r.log.Debugw("recieved track subscribed for unknown track", "trackID", trackSubscribed.TrackSid)
+		return
+	}
+	// r.callback.OnLocalTrackSubscribed(trackPublication, r.LocalParticipant)
+}
+
+func (r *Room) handleSubscribedQualityUpdate(subscribedQualityUpdate *livekit.SubscribedQualityUpdate) {
+	trackPublication := r.LocalParticipant.getLocalPublication(subscribedQualityUpdate.TrackSid)
+	if trackPublication == nil {
+		r.log.Debugw("recieved subscribed quality update for unknown track", "trackID", subscribedQualityUpdate.TrackSid)
+		return
+	}
+
+	r.log.Infow(
+		"handling subscribed quality update",
+		"trackID", trackPublication.SID(),
+		"mime", trackPublication.MimeType(),
+		"subscribedQualityUpdate", protoLogger.Proto(subscribedQualityUpdate),
+	)
+	for _, subscribedCodec := range subscribedQualityUpdate.SubscribedCodecs {
+		// for some reason, mime type is empty, since we are using only one codec, we can skip the check
+		// if !strings.HasSuffix(strings.ToLower(trackPublication.MimeType()), subscribedCodec.Codec) {
+		// 	continue
+		// }
+
+		for _, subscribedQuality := range subscribedCodec.Qualities {
+			track := trackPublication.GetSimulcastTrack(subscribedQuality.Quality)
+			if track != nil {
+				track.setMuted(!subscribedQuality.Enabled)
+				r.log.Infow(
+					"updating layer enable",
+					"trackID", trackPublication.SID(),
+					"quality", subscribedQuality.Quality,
+					"enabled", subscribedQuality.Enabled,
+				)
+			}
+		}
 	}
 }
 

--- a/signalclient.go
+++ b/signalclient.go
@@ -57,6 +57,8 @@ type SignalClient struct {
 	OnLocalTrackUnpublished func(response *livekit.TrackUnpublishedResponse)
 	OnTokenRefresh          func(refreshToken string)
 	OnLeave                 func(*livekit.LeaveRequest)
+	OnLocalTrackSubscribed    func(trackSubscribed *livekit.TrackSubscribed)
+	OnSubscribedQualityUpdate func(subscribedQualityUpdate *livekit.SubscribedQualityUpdate)
 }
 
 func NewSignalClient() *SignalClient {
@@ -371,6 +373,14 @@ func (c *SignalClient) handleResponse(res *livekit.SignalResponse) {
 	case *livekit.SignalResponse_TrackUnpublished:
 		if c.OnLocalTrackUnpublished != nil {
 			c.OnLocalTrackUnpublished(msg.TrackUnpublished)
+		}
+	case *livekit.SignalResponse_TrackSubscribed:
+		if c.OnLocalTrackSubscribed != nil {
+			c.OnLocalTrackSubscribed(msg.TrackSubscribed)
+		}
+	case *livekit.SignalResponse_SubscribedQualityUpdate:
+		if c.OnSubscribedQualityUpdate != nil {
+			c.OnSubscribedQualityUpdate(msg.SubscribedQualityUpdate)
 		}
 	}
 }


### PR DESCRIPTION
cherry-pick of https://github.com/livekit/server-sdk-go/pull/690 to `v2.2.1`

* Support dynacast.

* get mime from simulcast codec

* clean up

* comments

* logging

* use next sample time as it is adjusted for sample duration